### PR TITLE
Bump jQuery from 1.10.2 to 3.5.0 in /Online_Voting_System

### DIFF
--- a/Online_Voting_System/packages.config
+++ b/Online_Voting_System/packages.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net452" />
   <package id="AspNet.ScriptManager.bootstrap" version="3.0.0" targetFramework="net452" />
   <package id="AspNet.ScriptManager.jQuery" version="1.10.2" targetFramework="net452" />
   <package id="bootstrap" version="3.4.1" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
-  <package id="jQuery" version="1.10.2" targetFramework="net452" />
+  <package id="jQuery" version="3.5.0" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights" version="2.0.0" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="1.2.1" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.0.0" targetFramework="net452" />


### PR DESCRIPTION
Bumps jQuery from 1.10.2 to 3.5.0.

---
updated-dependencies:
- dependency-name: jQuery dependency-type: direct:production ...